### PR TITLE
feat: add optional You.com search integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Verifier Agent 也升级为明确的门禁策略，而不是只返回一串 crit
 - 自动抽取论文正文、版面结构、图表截图、表格、公式和摘要证据。
 - 使用 DAG / graph executor 组织论文理解流程，节点包括 ParsePaper、ExtractSections、SummarizeContribution、ExtractMethods、VerifyClaims 和 GenerateReport。
 - 内置多 Agent 分工：Reader 读论文，Extractor 抽取结构，Synthesizer 写总结，Critic / Verifier 检查可信度。
+- MCP server 额外提供可选的 `search_web` 工具，使用 You.com 搜索论文、作者和相关背景资料，未配置 `YDC_API_KEY` 时不会启用。
 - 构建 Grounding Map，把 intro、method、experiments 和 claims 映射回原文证据。
 - 构建 Paper-to-Knowledge Graph，提取 concept、method、dataset、evaluation 等节点和关系。
 - Verifier Agent 会检查 claim 是否能在原文中找到支撑，方法类 claim 是否落在 method 证据中，贡献类 claim 是否新增了原文没有的内容。

--- a/paper_agent/mcp_server.py
+++ b/paper_agent/mcp_server.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import contextlib
 import io
 import os
+from paper_agent.youcom_search import youcom_search
 
 
 def create_mcp_app() -> FastMCP:
@@ -67,6 +68,12 @@ def create_mcp_app() -> FastMCP:
     mono pdf file: {doc_mono.absolute()}
     dual pdf file: {doc_dual.absolute()}
     """
+
+    @mcp.tool()
+    def search_web(query: str, count: int = 5) -> str:
+        """Search the live web with You.com and return concise results."""
+
+        return youcom_search(query, count=count)
 
     return mcp
 

--- a/paper_agent/youcom_search.py
+++ b/paper_agent/youcom_search.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any
+import os
+
+import requests
+
+YOUCOM_SEARCH_URL = "https://ydc-index.io/v1/search"
+
+
+def _format_youcom_search_results(payload: dict[str, Any], *, count: int) -> str:
+    results = payload.get("results") or {}
+    web_results = results.get("web") or []
+    news_results = results.get("news") or []
+
+    lines = []
+    for label, items in (("Web", web_results), ("News", news_results)):
+        if not items:
+            continue
+        lines.append(f"{label} results:")
+        for idx, item in enumerate(items[:count], start=1):
+            title = item.get("title") or "Untitled"
+            url = item.get("url") or ""
+            description = item.get("description") or ""
+            snippets = item.get("snippets") or []
+            snippet_text = snippets[0] if snippets else description
+            lines.append(f"{idx}. {title}")
+            if url:
+                lines.append(f"   {url}")
+            if snippet_text:
+                lines.append(f"   {snippet_text}")
+        lines.append("")
+
+    if not lines:
+        return "No results returned by You.com."
+    return "\n".join(lines).rstrip()
+
+
+def youcom_search(query: str, *, count: int = 5, api_key: str | None = None) -> str:
+    api_key = api_key or os.getenv("YDC_API_KEY")
+    if not api_key:
+        return "You.com search is disabled until YDC_API_KEY is configured."
+
+    response = requests.get(
+        YOUCOM_SEARCH_URL,
+        params={"query": query, "count": count},
+        headers={"X-API-Key": api_key},
+        timeout=30,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return _format_youcom_search_results(payload, count=count)

--- a/test/test_youcom_search.py
+++ b/test/test_youcom_search.py
@@ -1,0 +1,61 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from paper_agent.youcom_search import _format_youcom_search_results, youcom_search
+
+
+class TestYoucomSearch(unittest.TestCase):
+    def test_formatting_uses_web_and_news_results(self):
+        payload = {
+            "results": {
+                "web": [
+                    {
+                        "title": "PaperAgent README",
+                        "url": "https://example.com/readme",
+                        "description": "Readme description",
+                        "snippets": ["Snippet text"],
+                    }
+                ],
+                "news": [
+                    {
+                        "title": "PaperAgent release",
+                        "url": "https://example.com/news",
+                        "description": "News description",
+                    }
+                ],
+            }
+        }
+
+        rendered = _format_youcom_search_results(payload, count=5)
+
+        self.assertIn("Web results:", rendered)
+        self.assertIn("PaperAgent README", rendered)
+        self.assertIn("https://example.com/readme", rendered)
+        self.assertIn("Snippet text", rendered)
+        self.assertIn("News results:", rendered)
+        self.assertIn("PaperAgent release", rendered)
+
+    def test_disabled_when_key_missing(self):
+        self.assertEqual(
+            youcom_search("paper agent", api_key=None),
+            "You.com search is disabled until YDC_API_KEY is configured.",
+        )
+
+    @patch("paper_agent.youcom_search.requests.get")
+    def test_search_requests_youcom_endpoint(self, mock_get):
+        response = Mock()
+        response.json.return_value = {"results": {"web": [] , "news": []}}
+        response.raise_for_status.return_value = None
+        mock_get.return_value = response
+
+        youcom_search("paper agent", count=3, api_key="test-key")
+
+        mock_get.assert_called_once()
+        _, kwargs = mock_get.call_args
+        self.assertEqual(kwargs["params"]["query"], "paper agent")
+        self.assertEqual(kwargs["params"]["count"], 3)
+        self.assertEqual(kwargs["headers"]["X-API-Key"], "test-key")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This adds an optional `search_web` MCP tool backed by the You.com Search API.

I kept this optional. The tool is only useful when the MCP server needs current web context around a paper, author, benchmark, or background topic, and nothing changes for existing users unless `YDC_API_KEY` is configured.

## What changed

- added `paper_agent.youcom_search` for the small You.com Search API wrapper and result formatting
- registered a new `search_web` tool in the existing MCP server
- documented the optional MCP search capability in the README
- added focused tests for request construction, formatting, and missing-key behavior

## Setup

Set:

```bash
export YDC_API_KEY=your_key_here
```

Then start the MCP server the same way as before.

## Usage example

Call:

```json
{
  "query": "latest multimodal reasoning benchmark",
  "count": 5
}
```

through the new `search_web` MCP tool.

The response returns concise web and news results with titles, URLs, and snippets.

## Validation

Ran:

```bash
uv run pytest test/test_youcom_search.py test/test_cli.py
```

## Fallback / error handling

- if `YDC_API_KEY` is missing, the integration returns a clear disabled message
- existing MCP behavior stays unchanged for users who do not configure You.com
- upstream HTTP failures still surface as request errors rather than silently changing behavior

Tracking issue: https://github.com/youdotcom-oss/integration-tracking/issues/97

Happy to adjust the tool shape if you prefer a different MCP naming or result format.
